### PR TITLE
Fix link and code

### DIFF
--- a/docs/10-custom-pages.md
+++ b/docs/10-custom-pages.md
@@ -50,11 +50,11 @@ end
 
 ## Customize the Menu
 
-See the [Menu](2-resource-customization.md#customize-the-menu) documentation.
+See the [Menu](2-resource-customization#customize-the-menu) documentation.
 
 ## Add a Sidebar
 
-See the [Sidebars](7-sidebars.md) documentation.
+See the [Sidebars](7-sidebars) documentation.
 
 ## Add an Action Item
 

--- a/docs/2-resource-customization.md
+++ b/docs/2-resource-customization.md
@@ -173,6 +173,7 @@ end
 ### Conditionally Showing / Hiding Menu Items
 
 Menu items can be shown or hidden at runtime using the `:if` option.
+
 ```ruby
 ActiveAdmin.register Post do
   menu if: proc{ current_user.can_edit_posts? }

--- a/docs/3-index-pages.md
+++ b/docs/3-index-pages.md
@@ -52,7 +52,7 @@ end
 ```
 
 Active Admin does not limit the index page to be a table, block, blog or grid.
-If you've [created your own index page](3-index-pages/create-an-index.md) it
+If you've [created your own index page](3-index-pages/create-an-index) it
 can be included by setting `:as` to the class of the index component you created.
 
 ```ruby


### PR DESCRIPTION
- Code of the chapter "Conditionally Showing / Hiding Menu Items" is not formatted. Like the following:
  ![code](https://cloud.githubusercontent.com/assets/6139686/17926725/4286fada-6a2d-11e6-9efd-0e4f3376f55e.jpg)
  http://activeadmin.info/docs/2-resource-customization.html#customize-the-menu
- 3 Links are 404. "Customize the Menu", "Add a Sidebar" and "Multiple Index Pages."
